### PR TITLE
Add schedule to container

### DIFF
--- a/base/python3-kafka/Dockerfile
+++ b/base/python3-kafka/Dockerfile
@@ -43,6 +43,9 @@ RUN apk add --no-cache --virtual .build-deps \
     # install beautifulsoup4
     && pip install beautifulsoup4 \
     \
+    # install schedule (scheduled task running in Python)
+    && pip install schedule \
+    \
     # install pykafka-tools
     && pip install git+https://github.com/smueller18/pykafka-tools.git@0.1.8#egg=pykafka-tools --process-dependency-links --allow-all-external \
     \


### PR DESCRIPTION
Add `schedule` to container to allow scheduled running of python tasks (necessary for forecast collector)