### PR TITLE
added basic authentication to access flink UI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       # nginx config files
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./nginx/http.conf:/etc/nginx/http.conf
+      # basic auth for Flink
+      - ./nginx/.htpasswd:/etc/nginx/.htpasswd
       - ${STCS_CONFIG_FOLDER-./../config}/nginx/conf.d:/etc/nginx/conf.d
       # password files
       - ${STCS_CONFIG_FOLDER-./../config}/nginx/htpasswd:/etc/nginx/htpasswd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       # nginx config files
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./nginx/http.conf:/etc/nginx/http.conf
+      # basic auth for Flink
+      - ./nginx/.htpasswd:/etc/nginx/.htpasswd
       - ${STCS_CONFIG_FOLDER-./../config}/nginx/conf.d:/etc/nginx/conf.d
       # password files
       - ${STCS_CONFIG_FOLDER-./../config}/nginx/htpasswd:/etc/nginx/htpasswd

--- a/nginx/.htpasswd
+++ b/nginx/.htpasswd
@@ -1,0 +1,1 @@
+flink-stcs:$apr1$mJDZZTe7$QyngN5nKGL8Bi7nyTFt8Q.

--- a/nginx/http.conf
+++ b/nginx/http.conf
@@ -124,6 +124,9 @@ server {
 server {
     listen 8081 ssl;
 
+    auth_basic                "Restricted";
+    auth_basic_user_file      /etc/nginx/.htpasswd;
+
     set $upstream http://flink-jobmanager:8081;
 
     include /etc/nginx/conf.d/http-server_name.conf;

--- a/nginx/http.conf
+++ b/nginx/http.conf
@@ -123,6 +123,9 @@ server {
 server {
     listen 8081 ssl;
 
+    auth_basic                "Restricted";
+    auth_basic_user_file      /etc/nginx/.htpasswd;
+
     set $upstream http://flink-jobmanager:8081;
 
     include /etc/nginx/conf.d/http-server_name.conf;


### PR DESCRIPTION
not tested, this should ask the user for a username + password before redirecting to the Flink UI. This would allow for better security since not everyone could connect to the Flink Dashboard and submit jobs.